### PR TITLE
Fix start of the link snap to center

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,5 +1,0 @@
-Issue to solve: https://github.com/konard/links-visuals/issues/1
-Your prepared branch: issue-1-323d61212181
-Your prepared working directory: /tmp/gh-issue-solver-1769989428786
-
-Proceed.


### PR DESCRIPTION
## Summary
- Fixed the left-chain IK mirroring logic in `animated-blueprint.html` that caused intermediate points (p1–p3) to jump from the left side to the right side of center when the start point snapped across the center x-axis

## Root Cause
The `updateIntermediateViaIK()` function used a conditional `mirrored` flag (`tgtL.x < root.x`) to decide whether to mirror the solver target and result. When grid snap moved the start point from just left of center to just right of center, this flag flipped from `true` to `false`, causing:
- The solver target to switch from mirrored-rightward to natural-rightward
- The arc result to no longer be mirrored back to the left side
- All intermediate points (p1, p2, p3) to suddenly appear on the right side of center

## Fix
Always mirror the left chain by:
1. Using `Math.abs(tgtL.x - root.x)` to always present the target to the right of root for the solver
2. Unconditionally mirroring the solver result back to the left side
3. Negating `preferredSide` when passing to/from the mirrored solver to maintain consistent curvature direction

This eliminates the discontinuity at the center boundary, ensuring smooth visual transitions regardless of which side of center the start point is on.

## Test plan
- [x] Verified start point drag below center works normally (curve extends left)
- [x] Verified start point drag above center works normally
- [x] Verified dragging start across center x-axis no longer causes p1–p3 to flip to the right side
- [x] Verified right chain (end point drag) is unaffected
- [x] Verified initial page load state is unchanged

Fixes #1

🤖 Generated with [Claude Code](https://claude.com/claude-code)