### PR TITLE
fix: make it possible to unsnap the start of the link

### DIFF
--- a/.gitkeep
+++ b/.gitkeep
@@ -1,6 +1,0 @@
-# Auto-generated file for PR creation
-# Issue: https://github.com/konard/links-visuals/issues/3
-# Branch: issue-3-289de0b96783
-# Timestamp: 2026-03-07T23:40:48.110Z
-# This file was created with --gitkeep-file (default)
-# It will be removed when the task is complete


### PR DESCRIPTION
## Summary

Fixes #3.

**Root cause:** In SVG, elements are painted in DOM order (painter's model). The `center` circle was appended after `start` in the SVG, so when the IK animation moves both circles to the same position, `center` sits visually on top and intercepts all pointer events — making it impossible to drag `start` away.

**Fix:** Added `.style("pointer-events", d => d.draggable ? "auto" : "none")` when creating the control circles. Since `center` already has `draggable: false` in the data model, it now correctly passes all pointer events through to the `start` circle beneath it.

This is a minimal, targeted fix: one line change, no restructuring of SVG DOM order or IK logic required.

## Test plan

- [ ] Open `animated-blueprint.html` in a browser
- [ ] Drag the green `start` circle (left endpoint) — animation activates
- [ ] Watch the IK solver animate; `start` may overlap with `center`
- [ ] Verify you can still click and drag `start` away from `center` (was previously impossible)
- [ ] Verify `end` (red circle) also remains draggable throughout
- [ ] Verify `center` circle is visually unchanged (still renders, just doesn't capture events)

🤖 Generated with [Claude Code](https://claude.com/claude-code)