### PR TITLE
feat: make intermediate points non-draggable and add link geometry offset config panel

### DIFF
--- a/.gitkeep
+++ b/.gitkeep
@@ -1,6 +1,0 @@
-# Auto-generated file for PR creation
-# Issue: https://github.com/konard/links-visuals/issues/6
-# Branch: issue-6-e2fa47bc6c7b
-# Timestamp: 2026-03-08T12:16:35.773Z
-# This file was created with --gitkeep-file (default)
-# It will be removed when the task is complete


### PR DESCRIPTION
## Summary

Implements two improvements for `animated-blueprint.html` requested in #6:

### 1. Intermediate points (p1–p6) are no longer draggable

- Set `draggable: false` on all six intermediate control points.
- `pointer-events: none` and the always-dashed outline follow automatically from the existing `draggable` flag, so no further changes are needed.
- The IK solver continues to own and update these points every animation frame; users can no longer interfere with them.

### 2. Bottom-right config panel for link geometry offset

A new semi-transparent navy panel in the **bottom-right** corner contains two range sliders:

| Slider | Effect |
|--------|--------|
| **Start offset** | Shifts the path's geometric start point along the chain toward `p1`, so the link visually separates from the start anchor when snapped to center |
| **End offset** | Shifts the path's geometric end point along the chain toward `p6`, so the link visually separates from the end anchor when snapped to center |

The offsets affect only the rendered SVG path. The actual anchor coordinates used by the IK solver are unchanged.

## Test plan

- [ ] Open `animated-blueprint.html` in a modern browser
- [ ] Verify p1–p6 circles cannot be clicked or dragged (always stay dashed)
- [ ] Drag `start` and `end` to enable animation — verify IK solver still animates the chain
- [ ] Move the **Start offset** slider: the path start should visually move toward `p1`
- [ ] Move the **End offset** slider: the path end should visually move toward `p6`
- [ ] Snap both endpoints to center; set non-zero offsets — verify the path no longer merges with the center point visually
- [ ] Resize the window — verify layout and path remain correct

🤖 Generated with [Claude Code](https://claude.com/claude-code)


Fixes #6